### PR TITLE
Add Applications & Sponsorships

### DIFF
--- a/backend/src/controllers/actorController.js
+++ b/backend/src/controllers/actorController.js
@@ -1,5 +1,5 @@
 import { actorModel } from '../models/actorModel.js';
-import { UserState } from '../shared/enums.js';
+import { BasicState } from '../shared/enums.js';
 
 export const find_all_actors = (req, res) => {
   actorModel.find({}, (err, actors) => {
@@ -64,7 +64,7 @@ export const delete_an_actor = (req, res) => {
 export const ban_an_actor = (req, res) => {
   actorModel.findOneAndUpdate(
     { _id: req.params.actorId },
-    { state: UserState.INACTIVE },
+    { state: BasicState.INACTIVE },
     { new: true },
     (err, actor) => {
       if (err) {
@@ -81,15 +81,20 @@ export const ban_an_actor = (req, res) => {
 };
 
 export const unban_an_actor = (req, res) => {
-  actorModel.findOneAndUpdate({ _id: req.params.actorId }, { state: UserState.ACTIVE }, { new: true }, (err, actor) => {
-    if (err) {
-      if (err.name === 'ValidationError') {
-        res.status(422).send(err);
+  actorModel.findOneAndUpdate(
+    { _id: req.params.actorId },
+    { state: BasicState.ACTIVE },
+    { new: true },
+    (err, actor) => {
+      if (err) {
+        if (err.name === 'ValidationError') {
+          res.status(422).send(err);
+        } else {
+          res.status(500).send(err);
+        }
       } else {
-        res.status(500).send(err);
+        res.json(actor);
       }
-    } else {
-      res.json(actor);
     }
-  });
+  );
 };

--- a/backend/src/models/actorModel.js
+++ b/backend/src/models/actorModel.js
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
 import moment from 'moment';
-import { UserState, Roles, Languages } from '../shared/enums.js';
+import { BasicState, Roles, Languages } from '../shared/enums.js';
 
 const { Schema } = mongoose;
 
@@ -34,8 +34,8 @@ const ActorSchema = new Schema(
     },
     state: {
       type: String,
-      enum: Object.values(UserState),
-      default: UserState.ACTIVE
+      enum: Object.values(BasicState),
+      default: BasicState.ACTIVE
     },
     createdAt: Number,
     updatedAt: Number

--- a/backend/src/models/applicationModel.js
+++ b/backend/src/models/applicationModel.js
@@ -1,19 +1,20 @@
 import mongoose from 'mongoose';
 import moment from 'moment';
+import { ApplicationState } from '../shared/enums.js';
 
 const { Schema } = mongoose;
 
 const ApplicationSchema = new Schema(
   {
-    explorer: { type: Schema.Types.ObjectId, ref: 'Actor', default: null },
+    explorer: { type: Schema.Types.ObjectId, ref: 'Actor', required: 'Please provide a explorer.' },
+    trip: { type: Schema.Types.ObjectId, ref: 'Trip', required: 'Please provide a trip.' },
+    comments: [String],
     state: {
       type: String,
-      required: true,
-      enum: ['pending', 'rejected', 'due', 'accepted'],
-      default: 'pending'
+      enum: Object.values(ApplicationState),
+      default: ApplicationState.PENDING
     },
-    rejectedReason: { type: String, default: null },
-    isPaid: { type: Boolean, default: false },
+    reasonRejected: { type: String, default: null },
     createdAt: Number,
     updatedAt: Number
   },
@@ -21,5 +22,9 @@ const ApplicationSchema = new Schema(
     timestamps: { currentTime: () => moment().unix() }
   }
 );
+
+ApplicationSchema.index({ explorer: 1 });
+ApplicationSchema.index({ trip: 1 });
+ApplicationSchema.index({ state: 1 });
 
 export const applicationModel = mongoose.model('Applications', ApplicationSchema);

--- a/backend/src/models/sponsorshipModel.js
+++ b/backend/src/models/sponsorshipModel.js
@@ -1,22 +1,23 @@
 import mongoose from 'mongoose';
 import moment from 'moment';
+import { BasicState } from '../shared/enums.js';
 
 const { Schema } = mongoose;
 
 const SponsorshipSchema = new Schema(
   {
+    sponsor: { type: Schema.Types.ObjectId, ref: 'Actor', required: 'Please provide a sponsor.' },
     trip: {
       type: Schema.Types.ObjectId,
       ref: 'Trip',
-      default: null
+      required: 'Please provide a trip.'
     },
-    banner: { type: String, default: null },
-    link: { type: String, default: null },
+    banner: { type: String, required: 'Please provide an image.' },
+    link: { type: String, required: 'Please provide a link to a landing page.' },
     state: {
       type: String,
-      required: true,
-      enum: ['active', 'inactive'],
-      default: 'active'
+      enum: Object.values(BasicState),
+      default: BasicState.INACTIVE
     },
     createdAt: Number,
     updatedAt: Number
@@ -25,5 +26,9 @@ const SponsorshipSchema = new Schema(
     timestamps: { currentTime: () => moment().unix() }
   }
 );
+
+SponsorshipSchema.index({ sponsor: 1 });
+SponsorshipSchema.index({ trip: 1 });
+SponsorshipSchema.index({ state: 1 });
 
 export const sponsorshipModel = mongoose.model('Sponsorships', SponsorshipSchema);

--- a/backend/src/routes/applicationRoutes.js
+++ b/backend/src/routes/applicationRoutes.js
@@ -1,28 +1,18 @@
 import {
-  find_all_applications,
-  create_an_application,
-  find_an_application,
-  update_an_application,
-  delete_an_application
+  findAllApplications,
+  createApplication,
+  findApplication,
+  updateApplication,
+  deleteApplication,
+  cancelApplication,
+  payApplication,
+  findApplicationsByStatus
 } from '../controllers/applicationController.js';
 
 export const applicationRoutes = (app) => {
-  /**
-   * @section applications
-   * @type get post
-   * @url /v1/applications
-   * @param {string}
-   */
-  app.route('/v1/applications').get(find_all_applications).post(create_an_application);
-
-  /**
-   * @section applications
-   * @type get put
-   * @url /v1/applications/:applicationId
-   */
-  app
-    .route('/v1/applications/:applicationId')
-    .get(find_an_application)
-    .put(update_an_application)
-    .delete(delete_an_application);
+  app.route('/v1/applications').get(findAllApplications).post(createApplication);
+  app.route('/v1/applications/status').get(findApplicationsByStatus);
+  app.route('/v1/applications/:applicationId').get(findApplication).put(updateApplication).delete(deleteApplication);
+  app.route('/v1/applications/:applicationId/cancel').patch(cancelApplication);
+  app.route('/v1/applications/:applicationId/pay').patch(payApplication);
 };

--- a/backend/src/routes/sponsorshipRoutes.js
+++ b/backend/src/routes/sponsorshipRoutes.js
@@ -1,28 +1,14 @@
 import {
-  find_all_sponsorships,
-  create_an_sponsorship,
-  find_an_sponsorship,
-  update_an_sponsorship,
-  delete_an_sponsorship
+  findAllSponsorships,
+  createSponsorship,
+  findSponsorship,
+  updateSponsorship,
+  deleteSponsorship,
+  paySponsorship
 } from '../controllers/sponsorshipController.js';
 
 export const sponsorshipRoutes = (app) => {
-  /**
-   * @section sponsorships
-   * @type get post
-   * @url /v1/sponsorships
-   * @param {string}
-   */
-  app.route('/v1/sponsorships').get(find_all_sponsorships).post(create_an_sponsorship);
-
-  /**
-   * @section sponsorships
-   * @type get put
-   * @url /v1/sponsorships/:sponsorshipId
-   */
-  app
-    .route('/v1/sponsorships/:sponsorshipId')
-    .get(find_an_sponsorship)
-    .put(update_an_sponsorship)
-    .delete(delete_an_sponsorship);
+  app.route('/v1/sponsorships').get(findAllSponsorships).post(createSponsorship);
+  app.route('/v1/sponsorships/:sponsorshipId').get(findSponsorship).put(updateSponsorship).delete(deleteSponsorship);
+  app.route('/v1/sponsorships/:sponsorshipId/pay').patch(paySponsorship);
 };

--- a/backend/src/shared/enums.js
+++ b/backend/src/shared/enums.js
@@ -1,13 +1,21 @@
 export const Roles = {
   EXPLORER: 'explorer',
-  SPONSORR: 'sponsor',
+  SPONSOR: 'sponsor',
   MANAGER: 'manager',
   ADMIN: 'admin'
 };
 
-export const UserState = {
+export const BasicState = {
   ACTIVE: 'active',
   INACTIVE: 'inactive'
+};
+
+export const ApplicationState = {
+  PENDING: 'pending',
+  REJECTED: 'rejected',
+  DUE: 'due',
+  ACCEPTED: 'accepted',
+  CANCELLED: 'cancelled'
 };
 
 export const Languages = {


### PR DESCRIPTION
- Rename `UserState` enum to `BasicState` for better abstraction
- Create `ApplicationState` enum
- Add CRUD operations to `Applications` and `Sponsorships` schemas
- Add pay logic to both schemas
- Add cancel logic to `Applications` schema
- Create indexes for both schemas
- Create aggregation for `Applications` schema


